### PR TITLE
Add footer, hero blocks - Mar 31, 2026

### DIFF
--- a/blocks/footer/footer-tokens.css
+++ b/blocks/footer/footer-tokens.css
@@ -13,7 +13,7 @@
   --footer-feedback-btn-padding: 8px 20px;
 
   /* legal band */
-  --footer-legal-bg: #004f9a;
+  --footer-legal-bg: #002E99;
   --footer-legal-text: #fff;
   --footer-legal-padding: 1.5rem;
   --footer-legal-link-gap: 6px 24px;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,5 +1,10 @@
 @import url('./hero-tokens.css');
 
+/* Standalone hero: full-width, no wrapper padding */
+.hero-container:not(.card-carousel-bidirectional-container) > .hero-wrapper {
+  padding: 0;
+}
+
 /* ===== Base Hero: centered text over full-cover background ===== */
 .hero {
   position: relative;
@@ -8,7 +13,9 @@
   display: flex;
   align-items: center;
   background-color: var(--color-walmart-blue);
-  border-radius: 8px;
+  border-radius: 0;
+  box-sizing: border-box;
+  height: 220px;
 }
 
 /* All hero content sits above the background */
@@ -186,8 +193,9 @@
 /* ===== Overlay hero (e.g. Spring Flowers banner): dark text, image bg ===== */
 .hero:has(.hero-overlays) {
   background-color: transparent;
-  padding: 32px 24px;
-  min-height: 200px;
+  padding: 16px 24px;
+  height: 252px;
+  min-height: unset;
   overflow: visible;
 }
 
@@ -355,8 +363,9 @@
   }
 
   .hero:has(.hero-overlays) {
-    padding: 24px 40px;
-    min-height: 280px;
+    padding: 16px 40px;
+    height: 252px;
+    min-height: unset;
   }
 
   .hero:has(.hero-overlays) > div > div {


### PR DESCRIPTION
Automated migration updates generated by Experience Modernization Agent.

Footer styling
And Hero banner height fixed

Changed files (2):
- blocks/footer/footer-tokens.css
- blocks/hero/hero.css

## Test URLs:

**footer**
- Before: https://main--summit-wmt--aemdemos.aem.page/footer.plain
- After: https://aem-20260331-1308--summit-wmt--aemdemos.aem.page/footer.plain

**index**
- Before: https://main--summit-wmt--aemdemos.aem.page/index.plain
- After: https://aem-20260331-1308--summit-wmt--aemdemos.aem.page/index.plain

**nav**
- Before: https://main--summit-wmt--aemdemos.aem.page/nav.plain
- After: https://aem-20260331-1308--summit-wmt--aemdemos.aem.page/nav.plain

